### PR TITLE
Add advanced Qdrant examples

### DIFF
--- a/rag_tutorial.ipynb
+++ b/rag_tutorial.ipynb
@@ -1,1 +1,238 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Продвинутое использование Qdrant для RAG"]}, {"cell_type": "markdown", "metadata": {}, "source": ["В этом блокноте мы продолжим изучение Qdrant и шаг за шагом построим минимальный pipeline Retrieval Augmented Generation (RAG)."]}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": ["from qdrant_client import QdrantClient\nfrom qdrant_client.models import PointStruct, VectorParams, Distance\nfrom sentence_transformers import SentenceTransformer\nfrom transformers import pipeline\n\nclient = QdrantClient(':memory:')\nencoder = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Шаг 1. Подготовка данных и индексирование"]}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": ["texts = [\n    \"Qdrant это векторная база данных с открытым исходным кодом.\",\n    \"Она обеспечивает быстрый поиск по большим наборам векторов.\",\n    \"Qdrant отлично подходит для проектов с использованием нейронных сетей.\",\n    \"Хранилище поддерживает фильтрацию по метаданным.\",\n    \"RAG комбинирует поиск документов и генерацию ответа.\"\n]\nembeddings = encoder.encode(texts)\ncollection_name = 'rag_tutorial'\nclient.recreate_collection(\n    collection_name=collection_name,\n    vectors_config=VectorParams(size=len(embeddings[0]), distance=Distance.COSINE)\n)\npoints = [PointStruct(id=i, vector=vec, payload={'text': text}) for i, (vec, text) in enumerate(zip(embeddings, texts))]\nclient.upsert(collection_name=collection_name, points=points)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Шаг 2. Поиск релевантных документов"]}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": ["query = 'Для чего нужен Qdrant?'\nquery_vec = encoder.encode(query)\nhits = client.search(collection_name=collection_name, query_vector=query_vec, limit=3)\nhits"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Шаг 3. Генерация ответа на основе найденных документов"]}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": ["context = '\n'.join(hit.payload['text'] for hit in hits)\nqa_prompt = f'Вопрос: {query}\nДокументы:\n{context}\nОтвет:'\ntext_generator = pipeline('text-generation', model='gpt2')\nanswer = text_generator(qa_prompt, max_new_tokens=50)[0]['generated_text']\nprint(answer)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Шаг 4. Дополнительные возможности"]}, {"cell_type": "markdown", "metadata": {}, "source": ["В Qdrant можно использовать фильтры, настраивать параметры поиска и хранить произвольные метаданные для более сложных сценариев."]}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Продвинутое использование Qdrant для RAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "В этом блокноте мы продолжим изучение Qdrant и шаг за шагом построим минимальный pipeline Retrieval Augmented Generation (RAG)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from qdrant_client import QdrantClient\nfrom qdrant_client.models import PointStruct, VectorParams, Distance\nfrom sentence_transformers import SentenceTransformer\nfrom transformers import pipeline\n\nclient = QdrantClient(':memory:')\nencoder = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Шаг 1. Подготовка данных и индексирование"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "texts = [\n    \"Qdrant это векторная база данных с открытым исходным кодом.\",\n    \"Она обеспечивает быстрый поиск по большим наборам векторов.\",\n    \"Qdrant отлично подходит для проектов с использованием нейронных сетей.\",\n    \"Хранилище поддерживает фильтрацию по метаданным.\",\n    \"RAG комбинирует поиск документов и генерацию ответа.\"\n]\nembeddings = encoder.encode(texts)\ncollection_name = 'rag_tutorial'\nclient.recreate_collection(\n    collection_name=collection_name,\n    vectors_config=VectorParams(size=len(embeddings[0]), distance=Distance.COSINE)\n)\npoints = [PointStruct(id=i, vector=vec, payload={'text': text}) for i, (vec, text) in enumerate(zip(embeddings, texts))]\nclient.upsert(collection_name=collection_name, points=points)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Шаг 2. Поиск релевантных документов"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "query = 'Для чего нужен Qdrant?'\nquery_vec = encoder.encode(query)\nhits = client.search(collection_name=collection_name, query_vector=query_vec, limit=3)\nhits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Шаг 3. Генерация ответа на основе найденных документов"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "context = '\n'.join(hit.payload['text'] for hit in hits)\nqa_prompt = f'Вопрос: {query}\nДокументы:\n{context}\nОтвет:'\ntext_generator = pipeline('text-generation', model='gpt2')\nanswer = text_generator(qa_prompt, max_new_tokens=50)[0]['generated_text']\nprint(answer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Шаг 4. Дополнительные возможности"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "В Qdrant можно использовать фильтры, настраивать параметры поиска и хранить произвольные метаданные для более сложных сценариев."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 1. Поиск с простым фильтром по метаданным\n",
+    "filter_ = Filter(must=[FieldCondition(key='category', match=MatchValue(value='article'))])\n",
+    "hits = client.search(collection_name=collection_name, query_vector=query_vec, filter=filter_, limit=5)\n",
+    "for hit in hits:\n",
+    "    print(hit.id, hit.payload)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 2. Сложный фильтр AND/OR\n",
+    "complex_filter = Filter(must=[FieldCondition(key='lang', match=MatchValue(value='ru'))],\n",
+    "                         should=[FieldCondition(key='rating', range=Range(gte=4))])\n",
+    "hits = client.search(collection_name=collection_name, query_vector=query_vec, filter=complex_filter, limit=3)\n",
+    "for hit in hits:\n",
+    "    print(hit.id, hit.payload)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 3. Фильтрация по диапазону числового значения\n",
+    "price_filter = Filter(must=[FieldCondition(key='price', range=Range(gte=10, lte=20))])\n",
+    "hits = client.search(collection_name=collection_name, query_vector=query_vec, filter=price_filter, limit=3)\n",
+    "for hit in hits:\n",
+    "    print(hit.id, hit.payload['price'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 4. Использование параметров поиска для повышения точности\n",
+    "params = SearchParams(hnsw_ef=256)\n",
+    "hits = client.search(collection_name=collection_name, query_vector=query_vec, limit=3, search_params=params)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 5. Сохранение произвольных метаданных\n",
+    "payload = {'text': 'пример текста', 'lang': 'ru', 'category': 'article'}\n",
+    "point = PointStruct(id=123, vector=encoder.encode(payload['text']).tolist(), payload=payload)\n",
+    "client.upsert(collection_name=collection_name, points=[point])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 6. Получение точек по фильтру\n",
+    "points = client.scroll(collection_name=collection_name, filter=filter_, limit=10)[0]\n",
+    "print('Найдено', len(points), 'точек')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 7. Обновление метаданных для точек\n",
+    "client.set_payload(collection_name=collection_name, payload={'rating': 5}, points=[123])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 8. Удаление точек по фильтру\n",
+    "client.delete(collection_name=collection_name, filter=complex_filter)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 9. Подсчет точек по фильтру\n",
+    "count = client.count(collection_name=collection_name, filter=filter_, exact=True).count\n",
+    "print('Всего', count)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 10. Рекомендации схожих элементов\n",
+    "recommendations = client.recommend(collection_name=collection_name, positive=[123], limit=5)\n",
+    "for hit in recommendations:\n",
+    "    print(hit.id)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 11. Итерация по результатам с помощью scroll\n",
+    "offset = None\n",
+    "while True:\n",
+    "    points, offset = client.scroll(collection_name=collection_name, offset=offset, limit=50)\n",
+    "    if not points:\n",
+    "        break\n",
+    "    process(points)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 12. Пакетный поиск для нескольких запросов\n",
+    "requests = [SearchRequest(vector=encoder.encode(q).tolist(), limit=3) for q in queries]\n",
+    "results = client.search_batch(collection_name=collection_name, requests=requests)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 13. Гибридный поиск с использованием BM25S\n",
+    "bm25_params = BM25SearchParams()\n",
+    "hybrid_results = client.search(collection_name=collection_name, query_vector=query_vec, query_text=query, search_params=bm25_params, limit=5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 14. Настройка весов для векторной и текстовой частей при гибридном поиске\n",
+    "bm25_params = BM25SearchParams(alpha=0.7)  # вес текстовой компоненты\n",
+    "hybrid_results = client.search(collection_name=collection_name, query_vector=query_vec, query_text=query, search_params=bm25_params, limit=5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Пример 15. Работа с результатами гибридного поиска\n",
+    "for hit in hybrid_results:\n",
+    "    print(hit.id, hit.payload.get('text'))\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- expand `rag_tutorial.ipynb` with step 4 examples
- include 15 new code cells covering filters, payloads, and BM25S hybrid search

## Testing
- `python - <<'PY' import json; json.load(open('rag_tutorial.ipynb')); print('valid'); PY`

------
https://chatgpt.com/codex/tasks/task_e_683f4d77c58883208a7e0b1d9fa352d2